### PR TITLE
Automating the "monitoring" part of gitGraber

### DIFF
--- a/gitGraber.py
+++ b/gitGraber.py
@@ -18,7 +18,6 @@ from pprint import pprint
 from termcolor import colored
 from urllib.parse import urlparse
 from multiprocessing.dummy import Pool
-#pip3 install python-crontab/added to requirements.txt
 from crontab import CronTab
 
 
@@ -309,7 +308,7 @@ parser.add_argument('-k', '--keyword', action='store', dest='keywordsFile', help
 parser.add_argument('-q', '--query', action='store', dest='query', help='Specify your query (-q "myorg")')
 parser.add_argument('-s', '--slack', action='store_true', help='Enable slack notifications', default=False)
 parser.add_argument('-tg', '--telegram', action='store_true', help='Enable telegram notifications', default=False)
-parser.add_argument('-m', '--monitor', action='store_true', help='Monitors your query by adding a cron job for every 15 mins',default=False)
+parser.add_argument('-m', '--monitor', action='store_true', help='Monitors your query by adding a cron job for every 30 mins',default=False)
 parser.add_argument('-w', '--wordlist', action='store', dest='wordlist', help='Create a wordlist that fills dynamically with discovered filenames on GitHub')
 args = parser.parse_args()
 

--- a/gitGraber.py
+++ b/gitGraber.py
@@ -56,7 +56,6 @@ def monitor():
             job.minute.every(30)
             my_cron.write() 
 
-
 def checkToken(content, tokensMap, tokensCombo):
     tokensFound = {}
     # For each type of tokens (ie 'AWS'...)

--- a/gitGraber.py
+++ b/gitGraber.py
@@ -35,21 +35,22 @@ def clean(result):
     return re.sub(tokens.CLEAN_TOKEN_STEP2, '', cleanToken)
 
 def monitor():
-        cmd='/usr/bin/python3 '+str(path_script)+'/gitGraber.py -q "'+args.query+'"'
-        my_cron = CronTab(user=True)
-        if config.SLACK_WEBHOOKURL:
-            if(args.wordlist):
-                job = my_cron.new(command=cmd+' -s -k '+args.keywordsFile+' -w '+args.wordlist+'')
-            else:
-                job = my_cron.new(command=cmd+' -s -k '+args.keywordsFile+'')
-        elif config.TELEGRAM_CONFIG or config.TELEGRAM_CONFIG.get("token") or config.TELEGRAM_CONFIG.get("chat_id"):
-            if(args.wordlist):
-                job = my_cron.new(command=cmd+' -tg -k '+args.keywordsFile+' -w '+args.wordlist+'')
-            else:
-                job = my_cron.new(command=cmd+' -tg -k '+args.keywordsFile+'')
+    cmd='/usr/bin/python3 '+str(path_script)+'/gitGraber.py -q "'+args.query+'"'
+    my_cron = CronTab(user=True)
+    if config.SLACK_WEBHOOKURL:
+        if(args.wordlist):
+            job = my_cron.new(command=cmd+' -s -k '+args.keywordsFile+' -w '+args.wordlist+'')
+        else:
+            job = my_cron.new(command=cmd+' -s -k '+args.keywordsFile+'')
+    elif config.TELEGRAM_CONFIG or config.TELEGRAM_CONFIG.get("token") or config.TELEGRAM_CONFIG.get("chat_id"):
+        if(args.wordlist):
+            job = my_cron.new(command=cmd+' -tg -k '+args.keywordsFile+' -w '+args.wordlist+'')
+        else:
+            job = my_cron.new(command=cmd+' -tg -k '+args.keywordsFile+'')
 
-        job.minute.every(30)
-        my_cron.write()    
+    job.minute.every(30)
+    my_cron.write()
+
 
 def checkToken(content, tokensMap, tokensCombo):
     tokensFound = {}

--- a/gitGraber.py
+++ b/gitGraber.py
@@ -37,19 +37,24 @@ def clean(result):
 def monitor():
     cmd='/usr/bin/python3 '+str(path_script)+'/gitGraber.py -q "'+args.query+'"'
     my_cron = CronTab(user=True)
-    if config.SLACK_WEBHOOKURL:
+    if args.slack and config.SLACK_WEBHOOKURL:
         if(args.wordlist):
             job = my_cron.new(command=cmd+' -s -k '+args.keywordsFile+' -w '+args.wordlist+'')
+            job.minute.every(30)
+            my_cron.write() 
         else:
             job = my_cron.new(command=cmd+' -s -k '+args.keywordsFile+'')
-    elif config.TELEGRAM_CONFIG or config.TELEGRAM_CONFIG.get("token") or config.TELEGRAM_CONFIG.get("chat_id"):
+            job.minute.every(30)
+            my_cron.write() 
+    elif args.telegram and (config.TELEGRAM_CONFIG or config.TELEGRAM_CONFIG.get("token") or config.TELEGRAM_CONFIG.get("chat_id")):
         if(args.wordlist):
             job = my_cron.new(command=cmd+' -tg -k '+args.keywordsFile+' -w '+args.wordlist+'')
+            job.minute.every(30)
+            my_cron.write() 
         else:
             job = my_cron.new(command=cmd+' -tg -k '+args.keywordsFile+'')
-
-    job.minute.every(30)
-    my_cron.write()
+            job.minute.every(30)
+            my_cron.write() 
 
 
 def checkToken(content, tokensMap, tokensCombo):

--- a/gitGraber.py
+++ b/gitGraber.py
@@ -18,6 +18,8 @@ from pprint import pprint
 from termcolor import colored
 from urllib.parse import urlparse
 from multiprocessing.dummy import Pool
+#pip3 install python-crontab/added to requirements.txt
+from crontab import CronTab
 
 
 def createEmptyBinaryFile(name):
@@ -32,6 +34,23 @@ def initFile(name):
 def clean(result):
     cleanToken = re.sub(tokens.CLEAN_TOKEN_STEP1, '', result.group(0))
     return re.sub(tokens.CLEAN_TOKEN_STEP2, '', cleanToken)
+
+def monitor():
+        cmd='/usr/bin/python3 '+str(path_script)+'/gitGraber.py -q "'+args.query+'"'
+        my_cron = CronTab(user=True)
+        if config.SLACK_WEBHOOKURL:
+            if(args.wordlist):
+                job = my_cron.new(command=cmd+' -s -k '+args.keywordsFile+' -w '+args.wordlist+'')
+            else:
+                job = my_cron.new(command=cmd+' -s -k '+args.keywordsFile+'')
+        elif config.TELEGRAM_CONFIG or config.TELEGRAM_CONFIG.get("token") or config.TELEGRAM_CONFIG.get("chat_id"):
+            if(args.wordlist):
+                job = my_cron.new(command=cmd+' -tg -k '+args.keywordsFile+' -w '+args.wordlist+'')
+            else:
+                job = my_cron.new(command=cmd+' -tg -k '+args.keywordsFile+'')
+
+        job.minute.every(30)
+        my_cron.write()    
 
 def checkToken(content, tokensMap, tokensCombo):
     tokensFound = {}
@@ -290,6 +309,7 @@ parser.add_argument('-k', '--keyword', action='store', dest='keywordsFile', help
 parser.add_argument('-q', '--query', action='store', dest='query', help='Specify your query (-q "myorg")')
 parser.add_argument('-s', '--slack', action='store_true', help='Enable slack notifications', default=False)
 parser.add_argument('-tg', '--telegram', action='store_true', help='Enable telegram notifications', default=False)
+parser.add_argument('-m', '--monitor', action='store_true', help='Monitors your query by adding a cron job for every 15 mins',default=False)
 parser.add_argument('-w', '--wordlist', action='store', dest='wordlist', help='Create a wordlist that fills dynamically with discovered filenames on GitHub')
 args = parser.parse_args()
 
@@ -304,12 +324,18 @@ if not args.query or args.query == "":
 
 keywordsFile = args.keywordsFile
 githubQuery = args.query
+path_script=os.path.dirname(os.path.realpath(__file__))
 config.GITHUB_TOKENS_STATES = {}
 checkedOrgs = {}
 
 # If wordlist, check if file is binary initialized for mmap 
 if(args.wordlist):
     initFile(args.wordlist)
+# If monitor, create crontab for every 15 mins by default[ re-construct users CLI ]
+if (args.monitor):
+    monitor()
+else:
+    pass
 
 # Init URL file 
 initFile(config.GITHUB_URL_FILE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-requests
-termcolor
-argcomplete
+requests==2.18.4
+argcomplete==1.10.0
+python_crontab==2.3.9
+termcolor==1.1.0


### PR DESCRIPTION
Hey there!

First off, great work on gitGraber!

The README contains the following recommendation -

```
We recommend creating a cron that will execute the script regulary :

*/15 * * * * cd /BugBounty/gitGraber/ && /usr/bin/python3 gitGraber.py -k wordlists/keywords.txt -q "uber" -s >/dev/null 2>&1
``` 

The above cron job will ensure regular execution of the script every 15 mins . This means that the user need not "repeat" the query with the same arguments, in short on adding the above cron job to the crontab the user can monitor the GitHub "query". 

The only issue i see here is that this could very easily be automated i.e the user need not always add cron jobs manually for every query of theirs. So i wanted to automate this by giving a choice to the end user.

My PR does 3 simple things -

- First creates an optional -m flag which stands for monitor.
- If the -m flag is present then this means that the user wants to monitor their query. So the script will then invoke the `monitor()` function & create a cron job with the same arguments passed by the user.
- if there is no -m flag, script runs as usual.

Hope you like the idea.

Thanks!