### PR TITLE
Fix wrong indentation

### DIFF
--- a/gitGraber.py
+++ b/gitGraber.py
@@ -72,8 +72,8 @@ def checkToken(content, tokensMap, tokensCombo):
                 for blacklistedPattern in blacklist:
                     if blacklistedPattern in cleanToken:
                         foundbl = True
-                if not foundbl:
-                    tokensFound[cleanToken] = token.getName()
+            if not foundbl:
+                tokensFound[cleanToken] = token.getName()
     
     for combo in tokensCombo:
         found = True


### PR DESCRIPTION
I believe that this two lines are responsible for many missed tokens from the results list:

When the Token has `blacklist` set to `[]` it evaluates to False. That means that for almost all tokens, code for adding found token to tokensFound was unreachable, causing missed results from the analysis.