### PR TITLE
Bump argcomplete-1.10.0 to 3.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.31.0
-argcomplete==1.10.0
+argcomplete==3.2.1
 python_crontab==2.3.9
 termcolor==1.1.0


### PR DESCRIPTION
Solve dependency error message on install.

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.                                                                                                                                                                             censys 2.2.9 requires argcomplete<4.0.0,>=2.0.0, but you have argcomplete 1.10.0 which is incompatible.

Created another fork for testing on a VM and error message is not showing.